### PR TITLE
Remove unnecessary dependencies from package.json to avoid NPM issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,5 @@
     "better-assert": "~1.0.0"
   },
   "author": "Gal Koren",
-  "license": "MIT",
-  "dependencies": {
-    "better-assert": "~1.0.0"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
There is no reason that I can see why you would need the `better-assert` module to be listed as a dependency (only as a devDependency).

Unfortunately, having it listed as a dependency can lead to major headaches for those of us using NPM shrinkwrap in new versions of NPM due to this bug: https://github.com/npm/npm/issues/15669